### PR TITLE
TransactionList: Store block range in URL

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -99,7 +99,22 @@ nav .inner {
   display:flex;
   justify-content:space-between;
 }
-nav .links > * {
+nav .links a {
+  opacity:0.6;
+
+  &.router-link-exact-active, &:not(:first-child).router-link-active {
+    opacity:1.0;
+
+    &:after {
+      content: "";
+      display:block;
+      position:absolute;
+      width:calc(100% - 20px);
+      left:10px;
+      border-top:3px solid #F7296E;
+      bottom:-8px;
+    }
+  }
 }
 nav a {
   @include font-size(m);
@@ -121,21 +136,6 @@ nav .logo {
 nav .logo img + *{
   margin-top:-12px;
   margin-left:5px;
-}
-nav a.link {
-  opacity:0.6;
-}
-nav a.router-link-exact-active {
-  opacity:1.0;
-}
-nav a.router-link-exact-active.link:after {
-  content: "";
-  display:block;
-  position:absolute;
-  width:calc(100% - 20px);
-  left:10px;
-  border-top:3px solid #F7296E;
-  bottom:-8px;
 }
 .screen {
   padding-bottom:130px;

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,13 +7,13 @@
           <span>explorer</span>
         </router-link>
         <div class="links">
-          <router-link class='link' to='/'>
+          <router-link to='/'>
             Dashboard
           </router-link>
-          <router-link class='link'  to='/blocks'>
+          <router-link to='/blocks'>
             Blocks
           </router-link>
-          <router-link class='link' to='/tx'>
+          <router-link to='/tx'>
             Transactions
           </router-link>
         </div>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -35,9 +35,10 @@ export default new Router({
       props: true
     },
     {
-      path: '/tx',
+      path: '/tx/:heightFrom?/:heightTo?',
       name: 'Transaction',
-      component: Transaction
+      component: Transaction,
+      props: true
     },
     {
       path: '/status',

--- a/src/screens/transaction/transaction.vue
+++ b/src/screens/transaction/transaction.vue
@@ -38,7 +38,7 @@
       </div>
       <div class='center'>
         <ae-button
-          @click="heightFrom -= 10"
+          :to="{ name: 'Transaction', params: { heightFrom: heightFrom - 10, heightTo } }"
           type='exciting' class="load-more"
         >
           Load more
@@ -61,10 +61,9 @@ export default {
     AePanel,
     Transaction
   },
+  props: ['heightFrom', 'heightTo'],
   data () {
     return {
-      heightFrom: 0,
-      heightTo: 0,
       newHeightFrom: 0,
       newHeightTo: 0
     }
@@ -81,24 +80,34 @@ export default {
   }),
   methods: {
     setNewHeight () {
-      this.heightFrom = this.newHeightFrom
+      this.$router.push({
+        name: 'Transaction',
+        params: {
+          heightFrom: this.newHeightFrom || this.heightFrom,
+          heightTo: this.newHeightTo || this.heightTo
+        }
+      })
       this.newHeightFrom = 0
-      this.heightTo = this.newHeightTo
       this.newHeightTo = 0
     },
     async checkParamsAndLoadTransactions () {
       const { heightFrom, heightTo } = this
       const { height } = this.$store.state
-      if (!heightFrom || !heightTo) {
-        this.heightFrom = height - 10
-        this.heightTo = height
+
+      const params =
+        ((!heightFrom || !heightTo) && {
+          heightFrom: height - 10,
+          heightTo: height
+        }) ||
+        ((heightFrom > heightTo || heightTo > height) && {
+          heightFrom: Math.min(heightFrom, heightTo, height),
+          heightTo: Math.min(Math.max(heightFrom, heightTo), height)
+        })
+      if (params) {
+        this.$router.replace({ name: 'Transaction', params })
         return
       }
-      if (heightFrom > heightTo || heightTo > height) {
-        this.heightFrom = Math.min(heightFrom, heightTo, height)
-        this.heightTo = Math.min(Math.max(heightFrom, heightTo), height)
-        return
-      }
+
       for (let height = this.heightFrom; height <= this.heightTo; height++) {
         this.$store.dispatch('loadBlock', { height })
       }


### PR DESCRIPTION
> Transaction menu link is not underlined anymore, probably has to do with the added suffix in the url.

It is fixed in this PR.

> I think the default link should not have a pagination offset in the url.

For default link, we can display last transactions with subscriptions to new transactions, but we shouldn't do it because the newly created block can bring a lot of transaction and it can be unclear from UX side.