### PR TITLE
added tx-type component

### DIFF
--- a/src/components/txType/txType.vue
+++ b/src/components/txType/txType.vue
@@ -1,0 +1,31 @@
+<template>
+  <component :is='tag' :class="['tx-type', txtype]">
+    {{txname}}
+  </component>
+</template>
+<script>
+import {
+  AeBadge
+} from '@aeternity/aepp-components'
+export default {
+  name: 'tx-type',
+  props: ['txtype', 'type'],
+  components: {
+    AeBadge
+  },
+  computed: {
+    tag () {
+      if (this.type === 'badge') return 'ae-badge'
+      if (this.type === 'h2') return 'h2'
+      return 'div'
+    },
+    txname () {
+      return this.txtype
+        .replace(/_tx$/, '')
+        .replace(/_/g, ' ')
+        .replace(/\w\S*/g, txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase())
+    }
+  }
+}
+</script>
+<style lang="scss"></style>


### PR DESCRIPTION
this component can display the type of a tx. can be a headline or ae-badge for the moment
```
            <tx-type type='badge' :txtype='transaction.tx.type'/>
```
<img width="91" alt="screen shot 2018-04-24 at 16 21 39" src="https://user-images.githubusercontent.com/415536/39193420-ca60ed3e-47db-11e8-9851-ee5e2ca6fb97.png">

---
```
        <tx-type v-if='transaction' type='h2' :txtype='transaction.tx.type'/>

```
<img width="142" alt="screen shot 2018-04-24 at 16 21 41" src="https://user-images.githubusercontent.com/415536/39193334-9afc250e-47db-11e8-84c8-a3687e6ef4b4.png">
