### PR TITLE
added ae-hash component

### DIFF
--- a/src/components/aeHash/aeHash.vue
+++ b/src/components/aeHash/aeHash.vue
@@ -40,7 +40,6 @@ export default {
   },
   computed: {
     displayAddress () {
-      if (this.type === 'full') { return this.hash }
       if (this.type === 'chunked') { return this.hash.match(/.{1,7}/g) }
       return this.hash
     }

--- a/src/components/aeHash/aeHash.vue
+++ b/src/components/aeHash/aeHash.vue
@@ -1,0 +1,49 @@
+<template>
+  <div :class="['ae-hash', `_type_${type}`]">
+    <div v-if="type === 'short'">
+      {{displayAddress | startAndEnd}}
+    </div>
+    <div v-else-if="type === 'chunked'">
+      <div v-for="chunk of displayAddress" class="chunk">
+        {{chunk}}
+      </div>
+    </div>
+    <div v-else>
+      {{displayAddress}}
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  name: 'ae-hash',
+  props: {
+    /**
+     * The hash to display.
+     */
+    'hash': {
+      type: String,
+      required: true
+    },
+
+    /**
+     * Show the 'full' hash, 'chunked' (full hash grouped by chunks ) or 'short' (show first 6 and last 6 characters)
+     */
+    'type': {
+      type: String,
+      default: 'full'
+    }
+  },
+  data () {
+    return {
+      showHash: false
+    }
+  },
+  computed: {
+    displayAddress () {
+      if (this.type === 'full') { return this.hash }
+      if (this.type === 'chunked') { return this.hash.match(/.{1,7}/g) }
+      return this.hash
+    }
+  }
+}
+</script>


### PR DESCRIPTION
simmilar to `ae-address`

suppose to visualise a `hash`. supports different view types. could be refactored into aepp-components

```
<ae-hash type='short' :hash='transaction.block_hash'/>
```
<img width="215" alt="screen shot 2018-04-24 at 16 27 12" src="https://user-images.githubusercontent.com/415536/39193696-733ac0f6-47dc-11e8-8981-0a31fa1bda6a.png">
