### PR TITLE
Replaced getAccountBalance with getAccountByPubkey

### DIFF
--- a/src/store/modules/accounts/actions.js
+++ b/src/store/modules/accounts/actions.js
@@ -19,7 +19,7 @@ export default {
     let balance = 0
 
     try {
-      balance = await client.api.getAccountBalance(address)
+      balance = (await client.api.getAccountByPubkey(address)).balance
     } catch (e) {
       balance = 0
     }


### PR DESCRIPTION
getAccountBalance seems to be missing from the aepp-sdk-js and getAccountByPubkey returns the full account object.