### PR TITLE
added z-index: -1 to recent-blocks

### DIFF
--- a/src/partials/recentBlocks/recentBlocks.scss
+++ b/src/partials/recentBlocks/recentBlocks.scss
@@ -1,6 +1,7 @@
 @import '../../style/mixins';
 
 .recent-blocks-partial {
+  z-index: -1;
   margin-top:80px;
   position:relative;
   > .inner {


### PR DESCRIPTION
Solved issue in pivotal tracker ticket: https://www.pivotaltracker.com/story/show/161285304
z-index issue, network status label is behind box (see screenshot)
![screen shot 2018-10-17 at 15 47 19](https://user-images.githubusercontent.com/18702420/48716069-8813ec00-ec3c-11e8-9503-c9a0b7ee6da4.png)
