### PR TITLE
Solve network status badge z-order problem

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -227,24 +227,4 @@ a {
 .slide-in-top-out {
   animation-direction: reverse;
 }
-.network-name {
-  text-transform:uppercase;
-  position:fixed;
-  right:20px;
-  @include font-size(xs);
-  font-weight:500;
-  padding:5px 7px;
-  background: #F7296E;
-  border-radius: 5px;
-  @include only-phone {
-    width:100%;
-    bottom:0;
-    left:0;
-    border-radius:0;
-    padding:15px 0;
-    margin:0;
-    text-align:center;
-    z-index:1;
-  }
-}
 [v-cloak] {display: none} /*used by v-cloak directive*/

--- a/src/app.vue
+++ b/src/app.vue
@@ -62,15 +62,8 @@
           </transition>
 
         </div>
-        <div>
-          <span v-if="VUE_APP_SHOW_NETWORK_STATS" is="router-link" to="/status/" class='network-name'>
-            {{ networkName }}
-          </span>
-          <!--<router-link to='/search'>-->
-          <!--<img src="@/assets/search.svg" alt=""/>-->
-          <!--</router-link>-->
+        <div />
         </div>
-      </div>
     </nav>
     <main>
       <router-view />
@@ -93,18 +86,6 @@ export default {
     }
   },
   computed: {
-    networkName () {
-      let url = this.$store.state.epochUrl
-      let name = url.replace(/(?:http(?:s)?:)?\/\/([^.]+).*/, '$1')
-      if (name) {
-        let shortname = name.replace(/([^.]+)-net-api/, '$1')
-        if (shortname) {
-          return `${shortname} network`
-        }
-        return name
-      }
-      return url
-    },
     pageName () {
       return ({
         'Index': 'Dashboard',

--- a/src/app.vue
+++ b/src/app.vue
@@ -63,22 +63,24 @@
 
         </div>
         <div />
-        </div>
+      </div>
     </nav>
     <main>
       <router-view />
     </main>
     <ae-footer />
+    <network-name />
   </div>
 </template>
 
 <script>
 import AeFooter from './partials/footer/footer'
 import SocialLinks from './partials/socialLinks'
+import networkName from './components/networkName'
 
 export default {
   name: 'app',
-  components: { AeFooter, SocialLinks },
+  components: { AeFooter, SocialLinks, networkName },
   data () {
     return {
       isOpened: false,

--- a/src/components/networkName.vue
+++ b/src/components/networkName.vue
@@ -36,6 +36,7 @@ export default {
 .network-name {
   text-transform:uppercase;
   position:fixed;
+  top: 30px;
   right:20px;
   color: $white;
   @include font-size(xs);
@@ -46,6 +47,7 @@ export default {
 
   @include only-phone {
     width:100%;
+    top: auto;
     bottom:0;
     left:0;
     border-radius:0;

--- a/src/components/networkName.vue
+++ b/src/components/networkName.vue
@@ -1,0 +1,58 @@
+<template>
+  <div>
+    <span v-if="VUE_APP_SHOW_NETWORK_STATS" is="router-link" to="/status/" class='network-name'>
+      {{ networkName }}
+    </span>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      VUE_APP_SHOW_NETWORK_STATS: process.env.VUE_APP_SHOW_NETWORK_STATS
+    }
+  },
+  computed: {
+    networkName () {
+      let url = this.$store.state.epochUrl
+      let name = url.replace(/(?:http(?:s)?:)?\/\/([^.]+).*/, '$1')
+      if (name) {
+        let shortname = name.replace(/([^.]+)-net-api/, '$1')
+        if (shortname) {
+          return `${shortname} network`
+        }
+        return name
+      }
+      return url
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '../style/mixins.scss';
+
+.network-name {
+  text-transform:uppercase;
+  position:fixed;
+  right:20px;
+  color: $white;
+  @include font-size(xs);
+  font-weight:500;
+  padding:5px 7px;
+  background: #F7296E;
+  border-radius: 5px;
+
+  @include only-phone {
+    width:100%;
+    bottom:0;
+    left:0;
+    border-radius:0;
+    padding:15px 0;
+    margin:0;
+    text-align:center;
+    z-index:1;
+  }
+}
+</style>


### PR DESCRIPTION
![networkname](https://user-images.githubusercontent.com/7098449/48753850-44bc8a80-ecdb-11e8-91d8-8f869cc87935.png)

I propose this solution for z-order problem with network status badge.

I've moved all related code to it's own component (`networkName.vue`) and injected this component to the bottom of `app.vue` template. This way it will be automatically rendered over other elements by browser. 

We use this solution in the base app (for example https://github.com/aeternity/aepp-base/blob/be5932caa87c20057051e73ac2b8596d42a8041f/src/pages/Accounts.vue#L73-L108) and this way we are not in need to use z-index to fix issues like that.