### PR TITLE
not using balance format from sdk

### DIFF
--- a/src/store/modules/accounts/actions.js
+++ b/src/store/modules/accounts/actions.js
@@ -15,7 +15,7 @@ export default wrapActionsWithResolvedEpoch({
     let balance = 0
 
     try {
-      balance = await epoch.balance(address)
+      balance = await epoch.balance(address, { format: false })
     } catch (e) {
       balance = 0
       throw new Error(e)


### PR DESCRIPTION
This is a temporary fix. And we'll use the format from sdk after some clarification.
Fixes #295 