### PR TITLE
moved connection check from node status to latestGeneration call

### DIFF
--- a/src/components/networkName.vue
+++ b/src/components/networkName.vue
@@ -23,11 +23,9 @@
 
 <script>
 import { AeLoader } from '@aeternity/aepp-components'
-import pollAction from '../mixins/pollAction'
 
 export default {
   components: { AeLoader },
-  mixins: [pollAction('getNodeStatus')],
   data () {
     return {
       VUE_APP_SHOW_NETWORK_STATS: process.env.VUE_APP_SHOW_NETWORK_STATS

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -70,19 +70,14 @@ const store = new Vuex.Store({
      * @return {Object}
      */
     async getNodeStatus ({ rootGetters: { epoch }, commit }) {
-      let connected = false
       try {
         const [top, version] = await Promise.all([
           epoch.api.getCurrentGeneration(),
           epoch.api.getStatus()
         ])
-        connected = true
-        commit('setNodeStatus', { connected, top, version })
-
-        return { connected, top, version }
+        commit('setNodeStatus', { connected: true, top, version })
+        return { connected: true, top, version }
       } catch (e) {
-        console.log(e)
-        commit('setNodeStatus', { connected })
         commit('catchError', 'Error', { root: true })
       }
     }

--- a/src/store/modules/blocks/actions.js
+++ b/src/store/modules/blocks/actions.js
@@ -153,6 +153,7 @@ export default wrapActionsWithResolvedEpoch({
    * @return {*}
    */
   async getLatestGenerations ({ state, rootGetters: { epoch }, commit, dispatch }, size) {
+    let connected = false
     try {
       await dispatch('height')
       const generations = await Promise.all(
@@ -162,9 +163,12 @@ export default wrapActionsWithResolvedEpoch({
       if (!generations.length) {
         return state.generations
       }
+      connected = true
       return generations
     } catch (e) {
       commit('catchError', 'Error', { root: true })
+    } finally {
+      this.commit('setNodeStatus', { connected }, { root: true })
     }
   }
 })


### PR DESCRIPTION
this PR reduces the multiple /status request done by the explorer